### PR TITLE
Listen on configured hostname

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,10 +96,15 @@ module.exports = function (opts) {
       //use configured port, or a random user port.
       var port = opts.port || 1024+(~~(Math.random()*(65536-1024)))
       var host = opts.host || nonPrivate.v4 || nonPrivate.private.v4 || '127.0.0.1'
+      var listenHost = opts.host
 
       var peers = api.peers = {}
 
-      var server = snet.createServer(setupRPC).listen(port)
+      var server = snet.createServer(setupRPC)
+      if (listenHost)
+        server.listen(port, listenHost)
+      else
+        server.listen(port)
 
       function setupRPC (stream, manf) {
         var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth)


### PR DESCRIPTION
This patch makes the server bind to the hostname given in the config option `host` if it is set; if `host` is not set, the behavior is unchanged and the server listens on a wildcard address.