### PR TITLE
Don't listen on opts.host

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports = function (opts) {
       var peers = api.peers = {}
 
       var server = snet.createServer(setupRPC)
-      server.listen(port, opts.host)
+      server.listen(port)
 
       function setupRPC (stream, manf) {
         var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth)


### PR DESCRIPTION
When running behind a NAT, listening on opts.host will point to an external ip, and not a local network interface, causing a stacktrace. 

Closes https://github.com/ssbc/scuttlebot/issues/296