### PR TITLE
support testnets

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ function each(obj, iter) {
 }
 
 function toBuffer(base64) {
-  return new Buffer(base64.substring(0, base64.indexOf('.')), 'base64')
+  if(Buffer.isBuffer(base64)) return base64
+  var i = base64.indexOf('.')
+  return new Buffer(~i ? base64.substring(0, i) : base64, 'base64')
 }
 
 function toSodiumKeys (keys) {
@@ -56,9 +58,8 @@ module.exports = function (opts) {
 
   create.createClient = function (opts) {
     if(opts.keys) opts.keys = toSodiumKeys(opts.keys)
-    if(opts.seed) opts.seed = new Buffer(opts.seed, 'base64')
-
-    opts.appKey = opts.appKey || appKey
+    if(opts.seed) opts.seed = toBuffer(opts.seed)
+    opts.appKey = toBuffer(opts.appKey || appKey)
 
     var snet = createNode(opts)
     return function (address, cb) {
@@ -83,7 +84,7 @@ module.exports = function (opts) {
       var snet = createNode({
         keys: opts.keys && toSodiumKeys(opts.keys),
         seed: opts.seed,
-        appKey: opts.appKey || appKey,
+        appKey: toBuffer(opts.appKey || appKey),
         authenticate: function (pub, cb) {
           var id = '@'+u.toId(pub)
           api.auth(id, function (err, auth) {
@@ -169,6 +170,7 @@ module.exports = function (opts) {
     }
   })
 }
+
 
 
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (opts) {
     if(opts.keys) opts.keys = toSodiumKeys(opts.keys)
     if(opts.seed) opts.seed = new Buffer(opts.seed, 'base64')
 
-    opts.appKey = appKey
+    opts.appKey = opts.appKey || appKey
 
     var snet = createNode(opts)
     return function (address, cb) {
@@ -83,7 +83,7 @@ module.exports = function (opts) {
       var snet = createNode({
         keys: opts.keys && toSodiumKeys(opts.keys),
         seed: opts.seed,
-        appKey: appKey,
+        appKey: opts.appKey || appKey,
         authenticate: function (pub, cb) {
           var id = '@'+u.toId(pub)
           api.auth(id, function (err, auth) {
@@ -143,7 +143,7 @@ module.exports = function (opts) {
         //cannot be called remote.
         connect: function (address, cb) {
           address = coearseAddress(address)
-
+          address.appKey = opts.appKey || appKey
           snet.connect(address, function (err, stream) {
             return err ? cb(err) : cb(null, setupRPC(stream))
           })

--- a/test/app-key.js
+++ b/test/app-key.js
@@ -1,0 +1,120 @@
+var Illuminati = require('../')
+var crypto = require('crypto')
+var tape = require('tape')
+var u = require('../util')
+
+var seeds = require('./seeds')
+
+//deterministic keys make testing easy.
+function hash (s) {
+  return crypto.createHash('sha256').update(s).digest()
+}
+
+var appkey1 = hash('test_key1')
+var appkey2 = hash('test_key2')
+
+var create = Illuminati({})
+
+create.use({
+  manifest: {
+    hello: 'sync',
+    aliceOnly: 'sync'
+  },
+  permissions: {
+    anonymous: { allow: ['hello'], deny: null }
+  },
+  init: function (api) {
+    return {
+      hello: function (name) {
+        return 'Hello, ' + name + '.'
+      },
+      aliceOnly: function () {
+        console.log('alice only')
+        return 'hihihi'
+      }
+    }
+  }
+})
+.use(function (api) {
+  api.auth.hook(function (fn, args) {
+    var cb = args.pop()
+    var id = args.shift()
+    fn(id, function (err, res) {
+      if(err) return cb(err)
+      if(id === '@'+u.toId(alice.publicKey))
+        cb(null, {allow: ['hello', 'aliceOnly']})
+      else cb()
+    })
+  })
+})
+
+var alice = create({
+  seed: seeds.alice, appKey: appkey1
+})
+
+var bob = create({
+  seed: seeds.bob, appKey: appkey1
+})
+
+var carol = create({
+  seed: seeds.carol, appKey: appkey1
+})
+
+tape('alice *can* use alice_only api', function (t) {
+  alice.connect(bob.address(), function (err, rpc) {
+    if(err) throw err
+    rpc.aliceOnly(function (err, data) {
+      if(err) throw err
+      t.equal(data, 'hihihi')
+      t.end()
+    })
+  })
+})
+
+tape('carol *cannot* use alice_only api', function (t) {
+  carol.connect(bob.address(), function (err, rpc) {
+    if(err) throw err
+    rpc.aliceOnly(function (err, data) {
+      t.ok(err)
+      t.end()
+    })
+  })
+})
+
+
+var antialice = create({
+  seed: seeds.alice, appKey: appkey2
+})
+
+var antibob = create({
+  seed: seeds.bob, appKey: appkey2
+})
+
+tape('antialice cannot connect to alice because they use different appkeys', function (t) {
+  antialice.connect(alice.address(), function (err, rpc) {
+    t.ok(err)
+    t.end()
+  })
+})
+
+
+tape('antialice can connect to antibob because they use the same appkeys', function (t) {
+  antialice.connect(antibob.address(), function (err, rpc) {
+    t.notOk(err)
+    t.end()
+  })
+})
+
+
+tape('cleanup', function (t) {
+  alice.close(true)
+  antialice.close(true)
+  bob.close(true)
+  antibob.close(true)
+  carol.close(true)
+  t.end()
+})
+
+
+
+

--- a/test/app-key.js
+++ b/test/app-key.js
@@ -10,10 +10,13 @@ function hash (s) {
   return crypto.createHash('sha256').update(s).digest()
 }
 
+var appkey0 = hash('test_key0')
 var appkey1 = hash('test_key1')
 var appkey2 = hash('test_key2')
 
-var create = Illuminati({})
+//set a default appkey, this will not actually be used
+//because everything downstream sets their appkey via config
+var create = Illuminati({appKey: appkey0})
 
 create.use({
   manifest: {

--- a/test/app-key.js
+++ b/test/app-key.js
@@ -11,7 +11,7 @@ function hash (s) {
 }
 
 var appkey0 = hash('test_key0')
-var appkey1 = hash('test_key1')
+var appkey1 = hash('test_key1').toString('base64')
 var appkey2 = hash('test_key2')
 
 //set a default appkey, this will not actually be used
@@ -117,6 +117,7 @@ tape('cleanup', function (t) {
   carol.close(true)
   t.end()
 })
+
 
 
 


### PR DESCRIPTION
this change allows the appkey to be set as a per-instance configuration option.
this will enable testnet instances which will never connect to the main net.
(the appkey is a part of secret handshake, and if two peers do not have the same appkey they will not be able to successfully establish a connection) This means we can easily run a testnet without much fuss, and people developing new things on top of ssb don't need to worry about pushing nonsense to something humans are using.

