### PR TITLE
Don't timeout RPC from self for inactivity

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,11 @@ module.exports = function (opts) {
       function setupRPC (stream, manf, isClient) {
         var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth)
         var rpcStream = rpc.createStream()
-        if(timeout_inactivity > 0) rpcStream = Inactive(rpcStream, timeout_inactivity)
+        var id = rpc.id = '@'+u.toId(stream.remote)
+        if(timeout_inactivity > 0 && id !== rpc.id) rpcStream = Inactive(rpcStream, timeout_inactivity)
         rpc.meta = stream.meta
 
         pull(stream, rpcStream, stream)
-
-        var id = rpc.id = '@'+u.toId(stream.remote)
 
         //keep track of current connections.
         if(!peers[id]) peers[id] = []

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tape": "^4.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls &&  npm test",
+    "prepublishOnly": "npm ls &&  npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/test/local.js
+++ b/test/local.js
@@ -1,0 +1,47 @@
+var Illuminati = require('../')
+var tape = require('tape')
+var u = require('../util')
+
+var seeds = require('./seeds')
+
+var appkey = new Buffer(32)
+
+var create = Illuminati({
+  appKey: appkey,
+})
+create.use({
+  manifest: {
+    ping: 'sync',
+  },
+  permissions: {
+    anonymous: { allow: ['ping'], deny: null }
+  },
+  init: function (api) {
+    return {
+      ping: function () {
+        return 'pong'
+      }
+    }
+  }
+})
+
+var alice = create({
+  seed: seeds.alice,
+  timeout: 100,
+})
+
+tape('do not timeout local client rpc', function (t) {
+  alice.connect(alice.address(), function (err, rpc) {
+    t.error(err, 'connect')
+    setTimeout(function () {
+      rpc.ping(function (err, pong) {
+        t.error(err, 'ping')
+        t.end()
+      })
+    }, 200)
+  })
+})
+
+tape.onFinish(function (t) {
+  alice.close(true)
+})


### PR DESCRIPTION
My sbot started shutting off periodically. I am running it with ssb-party and patchfoo. I found that patchfoo's rpc connection was getting closed by scuttlebot, and then ssb-party would shut down scuttlebot since there were no more clients connected. This PR restores the earlier behavior, from before b659eecf3512660c786bac707b54b0c10107a68a, of allowing clients to remain connected indefinitely. Note that client connections from a master key (for example, as described in `%9id5lKdgxl3ZleJa5BeMeAVLCnMwQepyntPLxisLnBE=.sha256`) will still get closed by the inactivity timeout. To allow for those, clients will have to use a keepalive.