### PR TITLE
Make --tor-only work with local sbot instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,17 +172,19 @@ module.exports = function (opts) {
 
       var peers = api.peers = {}
 
-      var protocols = [
+      var server_protocols = [
         [Net({port: port, host: host}), shs],
         [Onion({server: false}), shs]
       ]
+      var client_protocols = server_protocols
 
       if (opts["tor-only"])
-          protocols = [[Onion({server: false}), shs]]
+        client_protocols = [[Onion({server: false}), shs]]
 
-      var ms = MultiServer(protocols, msLogger)
+      var msServer = MultiServer(server_protocols, msLogger)
+      var msClient = MultiServer(client_protocols, msLogger)
 
-      var server = ms.server(setupRPC)
+      var server = msServer.server(setupRPC)
 
       function setupRPC (stream, manf, isClient) {
         var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth)
@@ -213,7 +215,7 @@ module.exports = function (opts) {
           return this.getAddress()
         },
         getAddress: function () {
-          return ms.stringify()
+          return msServer.stringify()
         },
         manifest: function () {
           return create.manifest
@@ -223,7 +225,7 @@ module.exports = function (opts) {
         },
         //cannot be called remote.
         connect: function (address, cb) {
-          ms.client(coearseAddress(address), function (err, stream) {
+          msClient.client(coearseAddress(address), function (err, stream) {
             return err ? cb(err) : cb(null, setupRPC(stream, null, true))
           })
         },


### PR DESCRIPTION
Rebased this on top of current version as there were some conflicts with my other version.