### PR TITLE
refactor to make protocols pluggable

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ module.exports = function (opts) {
         //can be called remotely.
         auth: function (pub, cb) { cb() },
         address: function () {
-          return this.getAddress()
+          return api.getAddress()
         },
         getAddress: function () {
           createServer(); return ms.stringify()
@@ -177,6 +177,9 @@ module.exports = function (opts) {
             transports.push(fn); return this
           },
           transform: function (fn) { transforms.push(fn); return this },
+          parse: function (str) {
+            return ms.parse(str)
+          }
         },
         close: function (err, cb) {
           if(isFunction(err)) cb = err, err = null
@@ -201,4 +204,5 @@ module.exports = function (opts) {
   .use(require('./plugins/net'))
   .use(require('./plugins/shs'))
 }
+
 

--- a/index.js
+++ b/index.js
@@ -118,8 +118,8 @@ module.exports = function (opts) {
           })
         })
 
-        msClient = msServer = MultiServer(suites)
-        server = msServer.server(setupRPC)
+        var ms = MultiServer(suites)
+        server = ms.server(setupRPC)
         return server
       }
 
@@ -154,7 +154,7 @@ module.exports = function (opts) {
           return this.getAddress()
         },
         getAddress: function () {
-          createServer(); return msServer.stringify()
+          createServer(); return ms.stringify()
         },
         manifest: function () {
           return create.manifest
@@ -165,13 +165,16 @@ module.exports = function (opts) {
         //cannot be called remote.
         connect: function (address, cb) {
           createServer()
-          msClient.client(coearseAddress(address), function (err, stream) {
+          ms.client(coearseAddress(address), function (err, stream) {
             return err ? cb(err) : cb(null, setupRPC(stream, null, true))
           })
         },
 
         multiserver: {
-          transport: function (fn) { transports.push(fn); return this },
+          transport: function (fn) {
+            if(server) throw new Error('cannot add protocol after server initialized')
+            transports.push(fn); return this
+          },
           transform: function (fn) { transforms.push(fn); return this },
         },
         close: function (err, cb) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 var u          = require('./util')
 var Api        = require('./api')
 var Muxrpc     = require('muxrpc')
@@ -101,7 +102,7 @@ module.exports = function (opts) {
         //function () { return shs }
       ]
 
-      var server, msServer, msClient
+      var server, ms
 
       function createServer () {
         if(server) return server
@@ -118,7 +119,7 @@ module.exports = function (opts) {
           })
         })
 
-        var ms = MultiServer(suites)
+        ms = MultiServer(suites)
         server = ms.server(setupRPC)
         return server
       }

--- a/index.js
+++ b/index.js
@@ -5,12 +5,6 @@ var pull       = require('pull-stream')
 var Rate       = require('pull-rate')
 
 var MultiServer = require('multiserver')
-var WS          = require('multiserver/plugins/ws')
-var Net         = require('multiserver/plugins/net')
-var Onion       = require('multiserver/plugins/onion')
-var Shs         = require('multiserver/plugins/shs')
-
-var nonPrivate = require('non-private-ip')
 var Inactive   = require('pull-inactivity')
 
 function isFunction (f) { return 'function' === typeof f }
@@ -25,21 +19,6 @@ function toBase64 (s) {
 function each(obj, iter) {
   if(Array.isArray(obj)) return obj.forEach(iter)
   for(var k in obj) iter(obj[k], k, obj)
-}
-
-function toBuffer(base64) {
-  if(Buffer.isBuffer(base64)) return base64
-  var i = base64.indexOf('.')
-  return new Buffer(~i ? base64.substring(0, i) : base64, 'base64')
-}
-
-function toSodiumKeys (keys) {
-  if(!(isString(keys.public) && isString(keys.private)))
-    return keys
-  return {
-    publicKey: toBuffer(keys.public),
-    secretKey: toBuffer(keys.private)
-  }
 }
 
 function coearseAddress (address) {
@@ -78,7 +57,8 @@ function msLogger (stream) {
 
 //opts must have appKey
 module.exports = function (opts) {
-
+  //this weird thing were some config is loaded first, then the rest later... not necessary.
+  var _opts = opts
   var appKey = (opts && opts.caps && opts.caps.shs || opts.appKey)
 
   opts.permissions = opts.permissions || {}
@@ -88,36 +68,8 @@ module.exports = function (opts) {
     init: function () {}
   }]: null)
 
-  create.createClient = function (opts) {
-    if(opts.keys) opts.keys = toSodiumKeys(opts.keys)
-    if(opts.seed) opts.seed = toBuffer(opts.seed)
-
-    var shs = Shs({
-      keys: opts.keys && toSodiumKeys(opts.keys),
-      seed: opts.seed && toBuffer(opts.seed),
-      appKey: toBuffer(opts.appKey || appKey),
-      timeout: opts.timeout || (opts.timers && opts.timers.handshake) || 10e3
-    })
-
-    var ms = MultiServer([
-      [Net({}), shs],
-      [Onion({}), shs],
-      [WS({}), shs]
-    ], msLogger)
-
-    return function (address, cb) {
-      address = coearseAddress(address)
-
-      return ms.client(address, function (err, stream) {
-        if(err) return cb(err)
-        var rpc = Muxrpc(opts.manifest || create.manifest, {})({})
-        pull(stream, rpc.createStream(), stream)
-        cb(null, rpc)
-      })
-    }
-  }
-
-  return create.use({
+  return create
+  .use({
     manifest: {
       auth: 'async',
       address: 'sync',
@@ -125,15 +77,14 @@ module.exports = function (opts) {
     },
     init: function (api, opts, permissions, manifest) {
 
+      //legacy, but needed to pass tests.
+      opts.appKey = opts.appKey || _opts.appKey
+
       //XXX: LEGACY CRUFT - TIMEOUTS
       var defaultTimeout = (
         opts.defaultTimeout || 5e3 // 5 seconds.
       )
-      var timeout_handshake, timeout_inactivity
-      if(opts.timers && !isNaN(opts.timers.handshake))
-        timeout_handshake = opts.timers.handshake
-
-      timeout_handshake = timeout_handshake || (opts.timers ? 15e3 : 5e3)
+      var timeout_inactivity
 
       if(opts.timers && !isNaN(opts.timers.inactivity))
         timeout_inactivity = opts.timers.inactivity
@@ -142,57 +93,43 @@ module.exports = function (opts) {
       //but if not, set a short default (as needed in the tests)
       timeout_inactivity = timeout_inactivity || (opts.timers ? 600e3 : 5e3)
 
-      //set all timeouts to one setting, needed in the tests.
-      if(opts.timeout)
-        timeout_handshake = timeout_inactivity = opts.timeout
-
-      var shsCap = (opts.caps && opts.caps.shs) || opts.appKey || appKey
-      var shs = Shs({
-        keys: opts.keys && toSodiumKeys(opts.keys),
-        seed: opts.seed,
-        appKey: toBuffer(shsCap),
-
-        //****************************************
-        timeout: timeout_handshake,
-
-        authenticate: function (pub, cb) {
-          var id = '@'+u.toId(pub)
-          api.auth(id, function (err, auth) {
-            if(err) cb(err)
-            else    cb(null, auth || create.permissions.anonymous)
-          })
-        }
-      })
-
-      //figure out the local key. take this from the shs plugin,
-      //because we may have only passed in a seed.
-      var id = '@'+u.toId(shs.publicKey)
-
-      //use configured port, or a random user port.
-      var port = opts.port || 1024+(~~(Math.random()*(65536-1024)))
-      var host = opts.host || nonPrivate.v4 || nonPrivate.private.v4 || '127.0.0.1'
-
       var peers = api.peers = {}
 
-      var server_protocols = [
-        [Net({port: port, host: host}), shs],
-        [Onion({server: false}), shs]
+      var transports = []
+
+      var transforms = [
+        //function () { return shs }
       ]
-      var client_protocols = server_protocols
 
-      if (opts["tor-only"])
-        client_protocols = [[Onion({server: false}), shs]]
+      var server, msServer, msClient
 
-      var msServer = MultiServer(server_protocols, msLogger)
-      var msClient = MultiServer(client_protocols, msLogger)
+      function createServer () {
+        if(server) return server
+        var suites = []
+        if(transforms.length < 1)
+          throw new Error('secret-stack needs at least 1 transform protocol')
 
-      var server = msServer.server(setupRPC)
+        transforms.forEach(function (createTransform, instance) {
+          transports.forEach(function (createTransport) {
+            suites.push([
+              createTransport(instance),
+              createTransform({})
+            ])
+          })
+        })
+
+        msClient = msServer = MultiServer(suites)
+        server = msServer.server(setupRPC)
+        return server
+      }
+
+      setImmediate(createServer)
 
       function setupRPC (stream, manf, isClient) {
-        var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth)
+        var rpc = Muxrpc(create.manifest, manf || create.manifest)(api, stream.auth === true ? create.permissions.anonymous : stream.auth)
         var rpcStream = rpc.createStream()
         rpc.id = '@'+u.toId(stream.remote)
-        if(timeout_inactivity > 0 && id !== rpc.id) rpcStream = Inactive(rpcStream, timeout_inactivity)
+        if(timeout_inactivity > 0 && api.id !== rpc.id) rpcStream = Inactive(rpcStream, timeout_inactivity)
         rpc.meta = stream.meta
 
         pull(stream, rpcStream, stream)
@@ -210,14 +147,14 @@ module.exports = function (opts) {
       }
 
       return {
+        config: opts,
         //can be called remotely.
-        publicKey: shs.publicKey,
         auth: function (pub, cb) { cb() },
         address: function () {
           return this.getAddress()
         },
         getAddress: function () {
-          return msServer.stringify()
+          createServer(); return msServer.stringify()
         },
         manifest: function () {
           return create.manifest
@@ -227,11 +164,16 @@ module.exports = function (opts) {
         },
         //cannot be called remote.
         connect: function (address, cb) {
+          createServer()
           msClient.client(coearseAddress(address), function (err, stream) {
             return err ? cb(err) : cb(null, setupRPC(stream, null, true))
           })
         },
 
+        multiserver: {
+          transport: function (fn) { transports.push(fn); return this },
+          transform: function (fn) { transforms.push(fn); return this },
+        },
         close: function (err, cb) {
           if(isFunction(err)) cb = err, err = null
           api.closed = true
@@ -251,6 +193,8 @@ module.exports = function (opts) {
       }
     }
   })
+  //default network plugins
+  .use(require('./plugins/net'))
+  .use(require('./plugins/shs'))
 }
-
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hoox": "0.0.1",
     "ip": "^1.1.5",
     "map-merge": "^1.1.0",
-    "multiserver": "^1.11.0",
+    "multiserver": "^1.12.0",
     "muxrpc": "^6.4.0",
     "non-private-ip": "^1.4.3",
     "pull-inactivity": "~2.1.1",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -1,0 +1,17 @@
+
+var Net = require('multiserver/plugins/net')
+var nonPrivate = require('non-private-ip')
+
+exports.name = 'multiserver-net'
+exports.version = '1.0.0'
+exports.mainfest = {}
+
+exports.init = function (ssk, config) {
+  var port = config.port || 1024+(~~(Math.random()*(65536-1024)))
+  var host = config.host || nonPrivate.v4 || nonPrivate.private.v4 || '127.0.0.1'
+
+  ssk.multiserver.transport(function (instance) {
+    return Net({host: config.host, port: config.port+instance || port})
+  })
+}
+

--- a/plugins/shs.js
+++ b/plugins/shs.js
@@ -1,0 +1,75 @@
+var u  = require('../util')
+var Shs = require('multiserver/plugins/shs')
+
+exports.name = 'multiserver-shs'
+exports.version = '1.0.0'
+exports.mainfest = {}
+
+function isFunction (f) { return 'function' === typeof f }
+function isString (s) { return 'string' === typeof s }
+function isObject (o) { return o && 'object' === typeof o && !Array.isArray(o) }
+
+function toBuffer(base64) {
+  if(Buffer.isBuffer(base64)) return base64
+  var i = base64.indexOf('.')
+  return new Buffer(~i ? base64.substring(0, i) : base64, 'base64')
+}
+
+function toSodiumKeys (keys) {
+  if(!(isString(keys.public) && isString(keys.private)))
+    return keys
+  return {
+    publicKey: toBuffer(keys.public),
+    secretKey: toBuffer(keys.private)
+  }
+}
+
+exports.init = function (api, config, permissions) {
+  var opts = config
+  var timeout_handshake
+  if(opts.timers && !isNaN(opts.timers.handshake))
+    timeout_handshake = opts.timers.handshake
+
+  timeout_handshake = timeout_handshake || (opts.timers ? 15e3 : 5e3)
+
+  //set all timeouts to one setting, needed in the tests.
+  if(opts.timeout)
+    timeout_handshake = timeout_inactivity = opts.timeout
+
+  var shsCap = (config.caps && config.caps.shs) || config.appKey
+  console.log('CAP', shsCap, config)
+  if(!shsCap) throw new Error('secret-stack/plugins/shs must have caps.shs configured')
+
+  var shs = Shs({
+    keys: config.keys && toSodiumKeys(config.keys),
+    seed: config.seed,
+    appKey: toBuffer(shsCap),
+
+    //****************************************
+    timeout: timeout_handshake,
+
+    authenticate: function (pub, cb) {
+      var id = '@'+u.toId(pub)
+      api.auth(id, function (err, auth) {
+        if(err) cb(err)
+        else    cb(null, auth || true)
+      })
+    }
+  })
+
+  var id = '@'+u.toId(shs.publicKey)
+  api.id = id
+  api.publicKey = id
+
+  api.multiserver.transform(function (instance) {
+    return shs
+  })
+}
+
+
+
+
+
+
+
+

--- a/plugins/shs.js
+++ b/plugins/shs.js
@@ -37,7 +37,6 @@ exports.init = function (api, config, permissions) {
     timeout_handshake = timeout_inactivity = opts.timeout
 
   var shsCap = (config.caps && config.caps.shs) || config.appKey
-  console.log('CAP', shsCap, config)
   if(!shsCap) throw new Error('secret-stack/plugins/shs must have caps.shs configured')
 
   var shs = Shs({
@@ -65,6 +64,7 @@ exports.init = function (api, config, permissions) {
     return shs
   })
 }
+
 
 
 

--- a/test/app-key.js
+++ b/test/app-key.js
@@ -44,7 +44,7 @@ create.use({
     var id = args.shift()
     fn(id, function (err, res) {
       if(err) return cb(err)
-      if(id === '@'+u.toId(alice.publicKey))
+      if(id === alice.id)
         cb(null, {allow: ['hello', 'aliceOnly']})
       else cb()
     })
@@ -96,6 +96,7 @@ var antibob = create({
 tape('antialice cannot connect to alice because they use different appkeys', function (t) {
   antialice.connect(alice.address(), function (err, rpc) {
     t.ok(err)
+    if(rpc) throw new Error('should not have connected successfully')
     t.end()
   })
 })

--- a/test/auth.js
+++ b/test/auth.js
@@ -42,7 +42,7 @@ create.use({
     var id = args.shift()
     fn(id, function (err, res) {
       if(err) return cb(err)
-      if(id === '@'+u.toId(alice.publicKey))
+      if(id === alice.id)
         cb(null, {allow: ['hello', 'aliceOnly']})
       else cb()
     })
@@ -88,4 +88,5 @@ tape('cleanup', function (t) {
   carol.close(true)
   t.end()
 })
+
 

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -28,9 +28,13 @@ var create = Illuminati({
   }
 })
 
-var alice = create({ seed: seeds.alice, timeout: 100, defaultTimeout: 5e3 })
+var alice = create({ seed: seeds.alice, timeout: 200, defaultTimeout: 5e3 })
 var carol = create({ seed: seeds.alice, timeout: 0, defaultTimeout: 10 })
-var bob = create({ seed: seeds.bob })
+var bob = create({ seed: seeds.bob , timeout: 200, defaultTimeout: 2000})
+
+tape('delay startup', function (t) {
+  setTimeout(t.end, 500)
+})
 
 tape('alice connects to bob', function (t) {
 
@@ -60,6 +64,5 @@ tape('cleanup', function (t) {
   alice.close(true); bob.close(true); carol.close(true)
   t.end()
 })
-
 
 


### PR DESCRIPTION
this is a refactor to make the relationship of transport and transform (aka security) much cleaner.

I don't want secret-stack/index to have new network protocols added to it, it's meant to be more high level than that. I've refactored to move those into plugins - net and shs are still hardwired in, but I left them there because they had always been part of this module anyway.

This means that a sbot plugin can now be the source of new networking (transport) protocols (or new crypto protocols!)

to add a network protocol, use plugins/net as the template, basically: call `transport(createMultiserverPlugin)`, note, createMultiserverPlugin 

note: in the case of multiple crypto (transform) protocols, createMultiserverPlugin is called with an `instance` which is an integer - if there are two transform protocols, it will be called with 0 then 1 - it should be added to the port, so that different crypto protocols do not collide.

This means we can cleanly add additional protocols @staltz @pietgeursen and also fix/improve secret-handshake @keks
