### PR TITLE
Respect opts.port and opts.host

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function (opts) {
       if (!opts.connections)
         opts.connections = {
           incoming: {
-            net: [{ scope: "public", "transform": "shs" }]
+            net: [{ scope: "public", "transform": "shs", port: opts.port, host: opts.host }]
           },
           outgoing: {
             net: [{ transform: "shs" }]


### PR DESCRIPTION
When creating default incoming 'net' connection, opts.port and opts.host
where ignored. This causes ssb-client/test/index.js to fail and breaks
backward compatibility.