### PR TITLE
assert that plugins expose their scope correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,9 @@ module.exports = function (opts) {
             transforms.forEach(function (transform) {
               transports.forEach(function (transport) {
                 if (transport.name == incTransportType && transform.name == conf.transform) {
+                  var trans = transport.create(conf)
+                  if(trans.scope() !== conf.scope)
+                    throw new Error('transport:'+transport.name +' did not remember scope, expected:' + conf.scope + ' got:'+trans.scope())
                   server_suites.push([
                     transport.create(conf),
                     transform.create()
@@ -190,7 +193,7 @@ module.exports = function (opts) {
         },
         getAddress: function (scope) {
           setupMultiserver()
-          return ms.stringify(scope)
+          return ms.stringify(scope) || null
         },
         manifest: function () {
           return create.manifest
@@ -248,5 +251,4 @@ module.exports = function (opts) {
   .use(require('./plugins/net'))
   .use(require('./plugins/shs'))
 }
-
 


### PR DESCRIPTION
I was trying to figure out what `sbot getAddress public` was reporting a `ws` address, when I had configured that in the `device` scope. Looking at the code I realized that it wasn't passing the configuration through! Looking at the other plugins, I also saw that several of them did not handle scopes correctly.

So this throws an error if the `proto.scope() !== conf.scope` (with helpful message)

And this helped me find that unix-socket, net and ws where all reporting scopes incorrectly.

I've also added a method `multiserver.scopes` which all your scoped address: `{<scope>: <getAddress(scope)>,..}`

I think this whole multiserver thing is on the verge of being a very excellent basis for building p2p applications, just a few more rough spots to polish!