### PR TITLE
Use multiserver's default values instead of a dupicated effort

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var Rate       = require('pull-rate')
 var MultiServer = require('multiserver')
 var Inactive   = require('pull-inactivity')
 
+var debug = require('debug')('secret-stack')
+
 function isFunction (f) { return 'function' === typeof f }
 function isString (s) { return 'string' === typeof s }
 function isObject (o) { return o && 'object' === typeof o && !Array.isArray(o) }
@@ -92,7 +94,7 @@ module.exports = function (opts) {
       // but if not, set a short default (as needed in the tests)
       timeout_inactivity = timeout_inactivity || (opts.timers ? 600e3 : 5e3)
 
-      if (!opts.connections)
+      if (!opts.connections) {
         opts.connections = {
           incoming: {
             net: [{ scope: "public", "transform": "shs", port: opts.port, host: opts.host }]
@@ -101,7 +103,7 @@ module.exports = function (opts) {
             net: [{ transform: "shs" }]
           }
         }
-
+      }
       var peers = api.peers = {}
 
       var transports = []
@@ -126,6 +128,7 @@ module.exports = function (opts) {
             transforms.forEach(function (transform) {
               transports.forEach(function (transport) {
                 if (transport.name == incTransportType && transform.name == conf.transform) {
+                  debug('creating server %s %s host=%s port=%d scope=%s', incTransportType, transform.name, conf.host, conf.port, conf.scope || 'undefined')
                   server_suites.push([
                     transport.create(conf),
                     transform.create()
@@ -211,11 +214,13 @@ module.exports = function (opts) {
             if(server) throw new Error('cannot add protocol after server initialized')
             if(!isObject(transport) && isString(transport.name) && isFunction(transport.create))
               throw new Error('transport must be {name: string, create: function}') 
+            debug('Adding transport %s', transport.name)
             transports.push(transport); return this
           },
           transform: function (transform) {
             if(!isObject(transform) && isString(transform.name) && isFunction(transform.create))
               throw new Error('transform must be {name: string, create: function}') 
+            debug('Adding transform %s', transform.name)
             transforms.push(transform); return this
           },
           parse: function (str) {

--- a/index.js
+++ b/index.js
@@ -95,12 +95,20 @@ module.exports = function (opts) {
       timeout_inactivity = timeout_inactivity || (opts.timers ? 600e3 : 5e3)
 
       if (!opts.connections) {
+        var net_in = { "transform": "shs"}
+        var net_out = { "transform": "shs"}
+        // avoid setting properties to value `undefined`
+        if (opts.host) net_in.host = opts.host
+        if (opts.port) {
+          net_in.port = opts.port
+          net_out.port = opts.port
+        }
         opts.connections = {
           incoming: {
-            net: [{ scope: "public", "transform": "shs", port: opts.port, host: opts.host }]
+            net: [net_in]
           },
           outgoing: {
-            net: [{ transform: "shs" }]
+            net: [net_out]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/ssbc/secret-stack.git"
   },
   "dependencies": {
+    "debug": "^4.1.0",
     "hoox": "0.0.1",
     "ip": "^1.1.5",
     "map-merge": "^1.1.0",

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -1,5 +1,6 @@
 var Net = require('multiserver/plugins/net')
 var nonPrivate = require('non-private-ip')
+var debug = require('debug')('secret-stack net plugin')
 
 exports.name = 'multiserver-net'
 exports.version = '1.0.0'
@@ -8,11 +9,10 @@ exports.mainfest = {}
 exports.init = function (ssk, config) {
   ssk.multiserver.transport({
     name: 'net',
-    create: function (netConfig) {
-      var port = netConfig.port || 1024+(~~(Math.random()*(65536-1024)))
-      var host = netConfig.host || nonPrivate.v4 || nonPrivate.private.v4 || '127.0.0.1'
-
-      return Net({host: host, port: port, scope: netConfig.scope, external: netConfig.external})
+    create: function (opts) {
+      debug('creating transport host=%s port=%d scope=%s', opts.host, opts.port, opts.scope)
+      // let multiserver figure out the defaults
+      return Net(opts)
     }
   })
 }


### PR DESCRIPTION
- Let multiserver plugins decide about default values for host, port and scope.
- Make sure not to put `port: undefined` or `host: undefined` into default connection
- Make sure default outgoing net connection has the same port as default incoming

How do you feel about the usage of the `debug` module here? I find it very useful.