### PR TITLE
first check if function-as-plugin has .init attached to it

### DIFF
--- a/api.js
+++ b/api.js
@@ -53,14 +53,14 @@ module.exports = function (plugins, defaultConfig) {
   create.permissions = {}
 
   create.use = function (plug) {
-    if(u.isFunction(plug))
-      return create.plugins.push({init: plug}), create
-
     if(Array.isArray(plug))
       return plug.forEach(create.use), create
 
-    if(!plug.init)
-      throw new Error('plugins *must* have "init" method')
+    if(!plug.init) {
+      if(u.isFunction(plug))
+        return create.plugins.push({init: plug}), create
+      else throw new Error('plugins *must* have "init" method')
+    }
 
     if(u.isString(plug.name))
       if(find(create.plugins, function (_plug) {


### PR DESCRIPTION
This should have no breaking change in secret-stack, because it just shuffles around some if conditions in `.use(plugin)`, giving priority to some shapes of `plugin` over others.

**Before:** any function plugin, no matter if it already had `.init` attached to it, would be wrapped in an object

**After:** before wrapping the function, we first check if it already has `.init` attached to it

As a result, this solves #41 and makes it possible to use a different shape for plugins.