### PR TITLE
Change loading an already loaded plugin from error to warning

### DIFF
--- a/api.js
+++ b/api.js
@@ -65,8 +65,10 @@ module.exports = function (plugins, defaultConfig) {
     if(u.isString(plug.name))
       if(find(create.plugins, function (_plug) {
         return _plug.name === plug.name
-      }))
-        throw new Error('plugin named:'+plug.name+' is already loaded')
+      })) {
+        console.error('plugin named:'+plug.name+' is already loaded, skipping')
+	return create
+      }
 
     var name = plug.name
     if(plug.manifest)


### PR DESCRIPTION
I wanted to make it so that ssb-minimal-pub-server loads the plugins needed for peer-invites by default, thus making it easier to configure. But found that if they had already been installed in ~/.ssb/plugins that it would just die. Seems as if it should be safe enough to just throw a warning instead of hard failing in such a case.