### PR TITLE
attach multiserver address to rpc object

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ var App = SecretStack({ appKey: '1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=' }
   .use(databasePlugin)
   .use(bluetoothPlugin)
 
-vap app = App(config)
+var app = App(config)
 ```
 
-For documentation on plugins, see [PLUGINS.md](./PLUGINS.md) 
+For documentation on plugins, see [PLUGINS.md](./PLUGINS.md).
 
 
 ## API
@@ -53,6 +53,15 @@ Start the app and returns an EventEmitter with methods (core and plugin) attache
 - ... - (optional)
 
 `config` will be passed to each plugin as they're initialised (as `merge(opts, config)` which opts were those options `SecretStack` factory was initialised with).
+
+This `app` as an EventEmitter emits the following events:
+
+- `'multiserver:listening'`: emitted once the app's multiserver server is set up successfully, with no arguments
+- `'rpc:connect'`: emitted every time a peer has been successfully connected with us, with the arguments:
+  - `rpc`: the muxrpc object to call the peer's remote functions, includes `rpc.stream` and `rpc.stream.address` (the multiserver address for this remote peer)
+  - `isClient`: a boolean indicating whether we are the client (true) or the server (false)
+- `'close'`: emitted once `app.close()` has finished teardown logic, with the arguments:
+  - `err`: if there was any error during closing
 
 ### app.getAddress()
 
@@ -102,8 +111,8 @@ Optionally takes `(err, callback)`
 
 ## TODO document
 
-> mix: I think some of these are exposed over muxrpc (as they're in the manifest) 
-and some can only be run locally if you have access to the instance of `app` you 
+> mix: I think some of these are exposed over muxrpc (as they're in the manifest)
+and some can only be run locally if you have access to the instance of `app` you
 got returned after initialising it.
 
 ### `app.id => String`  (alias `publicKey`)

--- a/core.js
+++ b/core.js
@@ -185,6 +185,7 @@ module.exports = {
         var rpcStream = rpc.stream
         if(timeout_inactivity > 0 && api.id !== rpc.id) rpcStream = Inactive(rpcStream, timeout_inactivity)
         rpc.meta = stream.meta
+        rpc.stream.address = stream.address
 
         pull(stream, rpcStream, stream)
 
@@ -229,13 +230,13 @@ module.exports = {
           transport: function (transport) {
             if(server) throw new Error('cannot add protocol after server initialized')
             if(!isObject(transport) && isString(transport.name) && isFunction(transport.create))
-              throw new Error('transport must be {name: string, create: function}') 
+              throw new Error('transport must be {name: string, create: function}')
             debug('Adding transport %s', transport.name)
             transports.push(transport); return this
           },
           transform: function (transform) {
             if(!isObject(transform) && isString(transform.name) && isFunction(transform.create))
-              throw new Error('transform must be {name: string, create: function}') 
+              throw new Error('transform must be {name: string, create: function}')
             debug('Adding transform %s', transform.name)
             transforms.push(transform); return this
           },

--- a/test/server.js
+++ b/test/server.js
@@ -50,12 +50,14 @@ tape('alice connects to bob', function (t) {
 
 tape('alice is client, bob is server', function (t) {
 
-  t.plan(2)
+  t.plan(4)
 
   alice.on('rpc:connect', function (rpc, isClient) {
+    t.true(rpc.stream.address.substr(0,4) === 'net:' && rpc.stream.address.length > 40);
     t.ok(isClient)
   })
   bob.on('rpc:connect', function (rpc, isClient) {
+    t.true(rpc.stream.address.substr(0,4) === 'net:' && rpc.stream.address.length > 40);
     t.notOk(isClient)
   })
 


### PR DESCRIPTION
Context: when Alice initiates an RPC connection with Bob over Bluetooth (Alice is the server, Bob is the client), I needed a way for Bob to know who connected to him, and not just their `rpc.id`, but also the multiserver address.

In many cases, the multiserver address is already known and was created in each multiserver plugin, by attaching `stream.address = address` before calling `onConnection(stream)`. That's the case for these plugins: `net`, `ws`, `unix`, `bluetooth`, etc. But this information was not passed forward to the `rpc` object.

This PR attaches `.address` to the rpc object. I considered doing it on `rpc.address`, but that's actually a muxrpc call itself, as well as `rpc.getAddress` is. It seemed natural that since there is `rpc.stream`, a duplex stream with the other peer, that we add that peer's address on `rpc.stream.address`.