### PR TITLE
convert new Buffer() to Buffer.from everywhere

### DIFF
--- a/plugins/shs.js
+++ b/plugins/shs.js
@@ -1,4 +1,4 @@
-var u  = require('../util')
+var u = require('../util')
 var Shs = require('multiserver/plugins/shs')
 
 exports.name = 'multiserver-shs'
@@ -9,10 +9,10 @@ function isFunction (f) { return 'function' === typeof f }
 function isString (s) { return 'string' === typeof s }
 function isObject (o) { return o && 'object' === typeof o && !Array.isArray(o) }
 
-function toBuffer(base64) {
+function toBuffer (base64) {
   if(Buffer.isBuffer(base64)) return base64
   var i = base64.indexOf('.')
-  return new Buffer(~i ? base64.substring(0, i) : base64, 'base64')
+  return Buffer.from(~i ? base64.substring(0, i) : base64, 'base64')
 }
 
 function toSodiumKeys (keys) {
@@ -34,7 +34,7 @@ exports.init = function (api, config, permissions) {
 
   //set all timeouts to one setting, needed in the tests.
   if(opts.timeout)
-    timeout_handshake = timeout_inactivity = opts.timeout
+    timeout_handshake =  opts.timeout
 
   var shsCap = (config.caps && config.caps.shs) || config.appKey
   if(!shsCap) throw new Error('secret-stack/plugins/shs must have caps.shs configured')
@@ -67,12 +67,3 @@ exports.init = function (api, config, permissions) {
     }
   })
 }
-
-
-
-
-
-
-
-
-

--- a/test/local.js
+++ b/test/local.js
@@ -1,10 +1,9 @@
 var Illuminati = require('../')
 var tape = require('tape')
-var u = require('../util')
 
 var seeds = require('./seeds')
 
-var appkey = new Buffer(32)
+var appkey = Buffer.alloc(32)
 
 var create = Illuminati({
   appKey: appkey,

--- a/test/seeds.js
+++ b/test/seeds.js
@@ -5,7 +5,7 @@
 //using vanity-ed25519 module.
 
 function S (base64) {
-  return new Buffer(base64, 'base64')
+  return Buffer.from(base64, 'base64')
 }
 
 exports.alice = S('8C37zWNNunT5q2K8hS9WX6FitXQ9kfU6uZLJV+Swc/s=')

--- a/util.js
+++ b/util.js
@@ -40,7 +40,7 @@ exports.parseAddress = function (e) {
 }
 
 var fromId = exports.fromId = function (id) {
-  return new Buffer(id.substring(0, id.indexOf('.')), 'base64')
+  return Buffer.from(id.substring(0, id.indexOf('.')), 'base64')
 }
 
 exports.toId = function (pub) {


### PR DESCRIPTION
what it says on the tin.

apparently this is a minor security win