### PR TITLE
Allow transforms to set their own identifiers

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -284,7 +284,14 @@ module.exports = {
             : permissions.anonymous,
         false
       )
+      // Legacy ID:
       rpc.id = _id
+      // Modern IDs:
+      for (const transform of transforms) {
+        if (transform.identify) {
+          rpc[transform.name] = transform.identify(stream.remote)
+        }
+      }
       let rpcStream = rpc.stream
       if (timeoutInactivity > 0 && api.id !== rpc.id) {
         rpcStream = Inactive(rpcStream, timeoutInactivity)

--- a/lib/core.js
+++ b/lib/core.js
@@ -289,7 +289,12 @@ module.exports = {
       // Modern IDs:
       for (const transform of transforms) {
         if (transform.identify) {
-          rpc[transform.name] = transform.identify(stream.remote)
+          const identified = transform.identify(stream.remote)
+          Object.defineProperty(rpc, transform.name, {
+            get () {
+              return identified
+            }
+          })
         }
       }
       let rpcStream = rpc.stream

--- a/lib/plugins/shs.js
+++ b/lib/plugins/shs.js
@@ -80,7 +80,7 @@ module.exports = {
     /**
      * @param {Buffer} publicKey
      */
-    function identify(publicKey) {
+    function identify (publicKey) {
       return {
         pubkey: publicKey.toString('base64')
       }
@@ -94,7 +94,7 @@ module.exports = {
     api.multiserver.transform({
       name: 'shs',
       create: () => shs,
-      identify,
+      identify
     })
   }
 }

--- a/lib/plugins/shs.js
+++ b/lib/plugins/shs.js
@@ -46,7 +46,7 @@ module.exports = {
       timeoutHandshake = config.timers?.handshake
     }
     if (!timeoutHandshake) {
-      timeoutHandshake = (config.timers ? 15e3 : 5e3)
+      timeoutHandshake = config.timers ? 15e3 : 5e3
     }
     // set all timeouts to one setting, needed in the tests.
     if (config.timeout) {
@@ -81,15 +81,24 @@ module.exports = {
      * @param {Buffer} publicKey
      */
     function identify (publicKey) {
+      const pubkey = publicKey.toString('base64')
       return {
-        pubkey: publicKey.toString('base64')
+        get pubkey () {
+          return pubkey
+        }
       }
     }
 
     const id = '@' + u.toId(shs.publicKey)
     api.id = id // Legacy ID
     api.publicKey = id
-    api.shs = identify(shs.publicKey) // Modern ID
+    // Modern ID
+    const identified = identify(shs.publicKey)
+    Object.defineProperty(api, 'shs', {
+      get () {
+        return identified
+      }
+    })
 
     api.multiserver.transform({
       name: 'shs',

--- a/lib/plugins/shs.js
+++ b/lib/plugins/shs.js
@@ -77,13 +77,24 @@ module.exports = {
       }
     })
 
+    /**
+     * @param {Buffer} publicKey
+     */
+    function identify(publicKey) {
+      return {
+        pubkey: publicKey.toString('base64')
+      }
+    }
+
     const id = '@' + u.toId(shs.publicKey)
-    api.id = id
+    api.id = id // Legacy ID
     api.publicKey = id
+    api.shs = identify(shs.publicKey) // Modern ID
 
     api.multiserver.transform({
       name: 'shs',
-      create: () => shs
+      create: () => shs,
+      identify,
     })
   }
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -23,6 +23,7 @@
  * @typedef {{
  *   name: string,
  *   create: () => unknown,
+ *   identify?: (publicKey: Buffer) => any,
  * }} Transform
  *
  * @typedef {{

--- a/test/auth2.js
+++ b/test/auth2.js
@@ -75,11 +75,21 @@ tape('bob has address', function (t) {
 tape('client calls server: alice -> bob', function (t) {
   t.ok(alice.id, 'has local legacy ID')
   t.ok(alice.shs.pubkey, 'has local modern ID')
+  const before = alice.shs.pubkey
+  alice.shs.pubkey = 'mutated'
+  const after = alice.shs.pubkey
+  t.equal(before, after, 'modern ID cannot be mutated')
 
   alice.connect(bob.getAddress('device') || bob.getAddress(), function (err, bobRpc) {
     if (err) throw err
     t.ok(bobRpc.id, 'has remote legacy ID')
     t.ok(bobRpc.shs.pubkey, 'has remote modern ID')
+
+    const before = bob.shs.pubkey
+    bob.shs.pubkey = 'mutated'
+    const after = bob.shs.pubkey
+    t.equal(before, after, 'modern ID cannot be mutated')
+
     bobRpc.hello(function (err, data) {
       t.notOk(err)
       t.ok(data)

--- a/test/auth2.js
+++ b/test/auth2.js
@@ -73,8 +73,13 @@ tape('bob has address', function (t) {
 })
 
 tape('client calls server: alice -> bob', function (t) {
+  t.ok(alice.id, 'has local legacy ID')
+  t.ok(alice.shs.pubkey, 'has local modern ID')
+
   alice.connect(bob.getAddress('device') || bob.getAddress(), function (err, bobRpc) {
     if (err) throw err
+    t.ok(bobRpc.id, 'has remote legacy ID')
+    t.ok(bobRpc.shs.pubkey, 'has remote modern ID')
     bobRpc.hello(function (err, data) {
       t.notOk(err)
       t.ok(data)


### PR DESCRIPTION
## Context

This work is motivated by PPPPP using secret-stack with new identifiers for peers based on their public key. 

## Problem

Currently, secret-stack hard codes IDs `@<BASE64>.ed25519`.

## Solution

I first thought about adding a special config that allows you to customize the peer ID to be whatever you want, but this was more complex to implement and also _requires_ you to configure such if you want a new ID system. That's not the _secret-stack way_, which so far has been mostly driven by plugins.

So what I went with instead is that secret-stack doesn't (or shouldn't) have a secret-stack-wide ID, but instead the *transform* plugins have the responsibility of determining the IDs. This is already true for secret handshake, because `lib/plugins/shs` is the one who sets `api.id`.

See the tests changed in this PR for a simple example.

So now

- `shs` => sets "legacy" `api.id = "@<BASE64>.ed25519"`
- `shs` => sets "modern" `api.shs.pubkey = "<BASE64>"` (this is the same as `secret` file `public` field)
- [`shse`](https://github.com/staltz/secret-handshake-ext/blob/7593631570c9a5e043cca67bf6137a756132dce6/lib/secret-stack-plugin.js#L72) => sets "modern" `api.shse.pubkey = "<BASE58>"`

So instead of using `ssb.id`, the modern way will be `ssb.shs.pubkey` or with PPPPP it's `ppppp.shse.pubkey`.