### PR TITLE
Support bare mode: no net, no shs

### DIFF
--- a/lib/bare.js
+++ b/lib/bare.js
@@ -1,0 +1,10 @@
+const Api = require('./api')
+
+/**
+ * @param {unknown} config
+ */
+module.exports = function SecretStack (config) {
+  const create = Api([], config ?? {})
+
+  return create.use(require('./core'))
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,29 @@
     "type": "git",
     "url": "git://github.com/ssb-js/secret-stack.git"
   },
+  "type": "commonjs",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/**/*"
   ],
+  "exports": {
+    ".": {
+      "require": "./lib/index.js"
+    },
+    "./bare": {
+      "require": "./lib/bare.js"
+    },
+    "./plugins/net": {
+      "require": "./lib/plugins/net.js"
+    },
+    "./plugins/shs": {
+      "require": "./lib/plugins/shs.js"
+    }
+  },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "debug": "^4.3.0",
     "hoox": "0.0.1",
@@ -21,9 +40,6 @@
     "pull-rate": "^1.0.2",
     "pull-stream": "^3.4.5",
     "to-camel-case": "^1.0.0"
-  },
-  "engines": {
-    "node": ">=16"
   },
   "devDependencies": {
     "@types/node": "^12.12.2",

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,6 @@
 var tape = require('tape')
 var crypto = require('crypto')
-var SecretStack = require('../lib')
+var SecretStack = require('../lib/bare')
 var seeds = require('./seeds')
 
 // deterministic keys make testing easy.
@@ -8,25 +8,26 @@ function hash (s) {
   return crypto.createHash('sha256').update(s).digest()
 }
 
-var appkey = hash('test_key')
+var appKey = hash('test_key')
 
-var create = SecretStack({
-  appKey: appkey
-}).use({
-  manifest: {
-    hello: 'sync'
-  },
-  permissions: {
-    anonymous: { allow: ['hello'], deny: null }
-  },
-  init: function (api) {
-    return {
-      hello: function (name) {
-        return 'Hello, ' + name + '.'
+var create = SecretStack({ appKey })
+  .use(require('../lib/plugins/net'))
+  .use(require('../lib/plugins/shs'))
+  .use({
+    manifest: {
+      hello: 'sync'
+    },
+    permissions: {
+      anonymous: { allow: ['hello'], deny: null }
+    },
+    init: function (api) {
+      return {
+        hello: function (name) {
+          return 'Hello, ' + name + '.'
+        }
       }
     }
-  }
-})
+  })
 
 var alice = create({ seed: seeds.alice })
 var bob = create({ seed: seeds.bob })


### PR DESCRIPTION
## Context

For PPPPP we want to use secret-stack, but with [shse](https://github.com/staltz/secret-handshake-ext) instead of **shs**.

## Problem

Secret-stack hardcodes `net` + `shs` and there's no way of opting out of this.

## Solution

Create an alternative to index.js, `bare.js` which can be imported as `require('secret-stack/bare')` which is only the core of secret-stack *without* `net` and `shs`, so users can opt-in themselves if they want. For PPPPPP this means I can opt-in to net and **shse**.

Not a breaking change, just a new feature.