### PR TITLE
plugin.needs to assert dependencies

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -12,6 +12,7 @@ Plugins are simply NodeJS modules that export an `object` of form `{ name, versi
 
 module.exports = {
   name: 'bluetooth',
+  needs: ['conn'],
   version: '5.0.1',
   manifest: {
     localPeers: 'async',
@@ -86,6 +87,15 @@ will be available at `node.fooBar`.
 
 A `plugin.name` can also be an `'object`. This object will be merged
 directly with the
+
+### `plugin.needs` (Array) _optional_
+
+An array of strings which are the names of other plugins that this plugin
+depends on. If those plugins are not present, then secret-stack will throw
+an error indicating that the dependency is missing.
+
+Use this field to declare dependencies on other plugins, and this should
+facilitate the correct usage of your plugin.
 
 ### `plugin.version` (String) _optional_
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -141,6 +141,16 @@ function Api (plugins, defaultConfig) {
       }
 
       const name = plugin.name
+
+      if (plugin.needs) {
+        for (const needed of plugin.needs) {
+          const found = create.plugins.some((p) => p.name === needed)
+          if (!found) {
+            throw new Error(`plugin "${name ?? '?'}" needs "${needed}" but not found`)
+          }
+        }
+      }
+
       if (plugin.manifest) {
         create.manifest = u.merge.manifest(
           create.manifest,

--- a/lib/api.js
+++ b/lib/api.js
@@ -146,7 +146,7 @@ function Api (plugins, defaultConfig) {
         for (const needed of plugin.needs) {
           const found = create.plugins.some((p) => p.name === needed)
           if (!found) {
-            throw new Error(`plugin "${name ?? '?'}" needs "${needed}" but not found`)
+            throw new Error(`plugin "${name ?? '?'}" needs plugin "${needed}" but not found`)
           }
         }
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -143,12 +143,14 @@ function Api (plugins, defaultConfig) {
       const name = plugin.name
 
       if (plugin.needs) {
-        for (const needed of plugin.needs) {
-          const found = create.plugins.some((p) => p.name === needed)
-          if (!found) {
-            throw new Error(`plugin "${name ?? '?'}" needs plugin "${needed}" but not found`)
+        queueMicrotask(() => {
+          for (const needed of plugin.needs) {
+            const found = create.plugins.some((p) => p.name === needed)
+            if (!found) {
+              throw new Error(`secret-stack plugin "${name ?? '?'}" needs plugin "${needed}" but not found`)
+            }
           }
-        }
+        })
       }
 
       if (plugin.manifest) {

--- a/test/api.js
+++ b/test/api.js
@@ -140,6 +140,39 @@ tape('plugin cannot be named global', function (t) {
   t.end()
 })
 
+tape('plugin needs another plugin', function (t) {
+  // core, not a plugin.
+  var Create = Api([{
+    manifest: {},
+    init: function (api) {
+      return {}
+    }
+  }])
+
+  t.throws(() => {
+    Create.use({
+      name: 'x',
+      needs: ['y'],
+      init: function () { }
+    })
+  }, 'throws on missing plugin')
+
+  Create.use({
+    name: 'foo',
+    init: function () { }
+  })
+
+  t.doesNotThrow(() => {
+    Create.use({
+      name: 'bar',
+      needs: ['foo'],
+      init: function () { }
+    })
+  }, 'does not throw on existing plugin')
+
+  t.end()
+})
+
 tape('compound (array) plugins', function (t) {
   // core, not a plugin.
   var Create = Api([{


### PR DESCRIPTION
## Context

In SSB and PPPPP it's common for SS plugins to need other plugins, so we have checks all over the place like this:

- https://github.com/ssbc/ssb-replication-scheduler/blob/aaf8849f9514cdb4660ef8ab90fad5f133ecfa04/index.js#L21-L28
- https://github.com/staltz/ppppp-conductor/blob/f35b368a41fe0764161c3d5bee9487eb1b7d1896/lib/index.js#L83-L87

## Problem

There's a lot of code repetition across various libraries, and it's easy to forget to check for one of these dependencies. Also, the custom error messages can differ from each other, and this can make it harder to detect that they are in fact the same kind of error.

## Solution

Fixing this in secret-stack is not hard, as you can see this is a small PR that adds just ~6 lines of code. Plugins would declare what they need, like this:

```js
module.exports = {
  name: 'bluetooth',
  needs: ['db', 'conn'], // <-----------
  manifest: {
    localPeers: 'async',
    updates: 'source'
  },
  init: (ssb, opts) => {
    // .. do things
  }
}
```

If a plugin called `db` was not loaded, then an error will be thrown:

```
Error: secret-stack plugin "bluetooth" needs plugin "db" but not found
```

## Considerations

`needs` looks like [depject](https://github.com/depject/depject)!

Hold on, it's different this time. Unlike depject, we are not *injecting* dependencies, and we don't have that whole web of "gives". All that's happening here is a small DSL for generating checks of presence of other plugins. Effectively, those checks already exist today! i.e. if you load such a plugin `bluetooth` and attempt to use `ssb.db.add`, it will error with `no property 'db' on undefined`. All that this PR is doing is making those errors more friendly and more debuggable.

This new `plugin.needs` metadata could also be useful in the future. We could implement secret-stack such that the order of loading plugins doesn't matter because we can traverse this DAG of "needs" and load them in topological order.